### PR TITLE
BUG: Docker image version

### DIFF
--- a/neurons/docker_utils.py
+++ b/neurons/docker_utils.py
@@ -1,25 +1,7 @@
-import socket
-import docker
-import bittensor as bt
+
+import os
+
 
 def get_docker_image_version():
-    return 'n/a'
-    """ temporary disable docker image version
-    try:
-        container_id = socket.gethostname()
-        client = docker.from_env()
-        container = client.containers.get(container_id)
-        image_details = container.image.tags
-        image_details = [x for x in image_details if x != 'latest']
-        if len(image_details) > 0:
-            return image_details[0]
-        else:
-            bt.logging.error(f"Could not find docker container with id: {container_id}")
-            return 'not found'
-    except docker.errors.NotFound as e:
-        bt.logging.error(f"Could not find docker container with id: {container_id}")
-        return 'n/a'
-    except Exception as e:
-        bt.logging.error(f"Could not get docker image version: {e}")
-        return 'n/a'
-    """
+    return os.getenv('VERSION', 'n/a')
+

--- a/neurons/docker_utils.py
+++ b/neurons/docker_utils.py
@@ -3,5 +3,5 @@ import os
 
 
 def get_docker_image_version():
-    return os.getenv('VERSION', 'n/a')
+    return os.getenv('DIGEST_CHARS', 'n/a')
 


### PR DESCRIPTION
Since we can't access container information directly from the container without mounting the docker daemon, which is a security risk, I am accessing that information from the environment variables which involves [Ops PR #15](https://github.com/blockchain-insights/blockchain-data-subnet-ops/pull/15) or returning n/a if it's not found.