### PR TITLE
SN1-267 Find the threshold for V1 version fixed score

### DIFF
--- a/neurons/miners/blacklist.py
+++ b/neurons/miners/blacklist.py
@@ -2,7 +2,6 @@ import bittensor as bt
 
 from insights import protocol
 from neurons.miners.query import is_query_only
-import random
 import typing
 import time
 
@@ -136,6 +135,4 @@ def base_blacklist(self, synapse: bt.Synapse) -> typing.Tuple[bool, str]:
         return True, f"Blacklisted hotkey: {hotkey}"
     if hotkey not in self.miner_config.whitelisted_hotkeys and self.config.mode == 'prod':
         return True, f"Not Whitelisted hotkey: {hotkey}"
-    if hotkey not in self.miner_config.inmemory_hotkeys and random.random() < self.miner_config.penality_rate:
-        return True, f"Not Inmemory hotkey"
     return False, "Hotkey recognized"

--- a/neurons/miners/blacklist.py
+++ b/neurons/miners/blacklist.py
@@ -2,7 +2,7 @@ import bittensor as bt
 
 from insights import protocol
 from neurons.miners.query import is_query_only
-
+import random
 import typing
 import time
 
@@ -136,4 +136,6 @@ def base_blacklist(self, synapse: bt.Synapse) -> typing.Tuple[bool, str]:
         return True, f"Blacklisted hotkey: {hotkey}"
     if hotkey not in self.miner_config.whitelisted_hotkeys and self.config.mode == 'prod':
         return True, f"Not Whitelisted hotkey: {hotkey}"
+    if hotkey not in self.miner_config.inmemory_hotkeys and random.random() < self.miner_config.penality_rate:
+        return True, f"Not Inmemory hotkey"
     return False, "Hotkey recognized"

--- a/neurons/remote_config.py
+++ b/neurons/remote_config.py
@@ -131,7 +131,7 @@ class ValidatorConfig(RemoteConfig):
         self.is_grace_period = None
         
         ## Added grace_threshold_block
-        self.grace_threshold_block = 1e+5
+        self.grace_threshold_score = 0.428844
         
         
         self.config_url = os.getenv("VALIDATOR_REMOTE_CONFIG_URL", 'https://subnet-15-cfg.s3.fr-par.scw.cloud/validator3.json')
@@ -152,7 +152,7 @@ class ValidatorConfig(RemoteConfig):
         self.blockchain_recency_weight = self.get_config_value('blockchain_recency_weight',  {"bitcoin": 2, "doge": 2})
         self.is_grace_period = self.get_config_value('is_grace_period', False)
         
-        self.grace_threshold_block = self.get_config_value('grace_threshold_block', 1e+5)
+        self.grace_threshold_score = self.get_config_value('grace_threshold_score', 0.428844)
         return self
 
     def get_blockchain_min_blocks(self, network):

--- a/neurons/remote_config.py
+++ b/neurons/remote_config.py
@@ -128,8 +128,9 @@ class ValidatorConfig(RemoteConfig):
         self.blockchain_recency_weight = None
         self.is_grace_period = None
         
-        ## Added grace_threshold
-        self.grace_threshold = 0.0
+        ## Added grace_threshold_block
+        self.grace_threshold_block = 1e+5
+        
         
         self.config_url = os.getenv("VALIDATOR_REMOTE_CONFIG_URL", 'https://subnet-15-cfg.s3.fr-par.scw.cloud/validator3.json')
 
@@ -149,7 +150,7 @@ class ValidatorConfig(RemoteConfig):
         self.blockchain_recency_weight = self.get_config_value('blockchain_recency_weight',  {"bitcoin": 2, "doge": 2})
         self.is_grace_period = self.get_config_value('is_grace_period', False)
         
-        self.grace_threshold = self.get_config_value('grace_threshold', 0.0)
+        self.grace_threshold_block = self.get_config_value('grace_threshold_block', 1e+5)
         return self
 
     def get_blockchain_min_blocks(self, network):

--- a/neurons/remote_config.py
+++ b/neurons/remote_config.py
@@ -95,7 +95,8 @@ class MinerConfig(RemoteConfig):
         self.config_url = os.getenv("MINER_REMOTE_CONFIG_URL", 'https://subnet-15-cfg.s3.fr-par.scw.cloud/miner.json')
         self.blockchain_sync_delta = None
         self.is_grace_period = None
-
+        self.inmemory_hotkeys = []
+        self.penalty_rate = 0
     def load_and_get_config_values(self):
         # Load remote configuration
         self.load_remote_config()
@@ -108,7 +109,8 @@ class MinerConfig(RemoteConfig):
         self.whitelisted_hotkeys = self.get_config_value('whitelisted_hotkeys', ["5FFApaS75bv5pJHfAp2FVLBj9ZaXuFDjEypsaBNc1wCfe52v", "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN", "5EhvL1FVkQPpMjZX4MAADcW42i3xPSF1KiCpuaxTYVr28sux", "5CXRfP2ekFhe62r7q3vppRajJmGhTi7vwvb2yr79jveZ282w", "5DvTpiniW9s3APmHRYn8FroUWyfnLtrsid5Mtn5EwMXHN2ed", "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3", "5Hddm3iBFD2GLT5ik7LZnT3XJUnRnN8PoeCFgGQgawUVKNm8", "5HEo565WAy4Dbq3Sv271SAi7syBSofyfhhwRNjFNSM2gP9M2", "5FcXnzNo3mrqReTEY4ftkg5iXRBi61iyvM4W1bywZLRqfxAY", "5HNQURvmjjYhTSksi8Wfsw676b4owGwfLR2BFAQzG7H3HhYf", "5FLKnbMjHY8LarHZvk2q2RY9drWFbpxjAcR5x8tjr3GqtU6F", "5Gpt8XWFTXmKrRF1qaxcBQLvnPLpKi6Pt2XC4vVQR7gqNKtU"])
         self.blockchain_sync_delta = self.get_config_value('blockchain_sync_delta', {'bitcoin': 100, 'doge': 100})
         self.is_grace_period = self.get_config_value('is_grace_period', False)
-
+        self.inmemory_hotkeys = self.get_config_value('inmemory_hotkeys', [])
+        self.penalty_rate = self.get_config_value('penalty_rate', 0.3)
         return self
     
     def get_blockchain_sync_delta(self, network):

--- a/neurons/remote_config.py
+++ b/neurons/remote_config.py
@@ -95,8 +95,6 @@ class MinerConfig(RemoteConfig):
         self.config_url = os.getenv("MINER_REMOTE_CONFIG_URL", 'https://subnet-15-cfg.s3.fr-par.scw.cloud/miner.json')
         self.blockchain_sync_delta = None
         self.is_grace_period = None
-        self.inmemory_hotkeys = []
-        self.penalty_rate = 0
     def load_and_get_config_values(self):
         # Load remote configuration
         self.load_remote_config()
@@ -109,8 +107,6 @@ class MinerConfig(RemoteConfig):
         self.whitelisted_hotkeys = self.get_config_value('whitelisted_hotkeys', ["5FFApaS75bv5pJHfAp2FVLBj9ZaXuFDjEypsaBNc1wCfe52v", "5HK5tp6t2S59DywmHRWPBVJeJ86T61KjurYqeooqj8sREpeN", "5EhvL1FVkQPpMjZX4MAADcW42i3xPSF1KiCpuaxTYVr28sux", "5CXRfP2ekFhe62r7q3vppRajJmGhTi7vwvb2yr79jveZ282w", "5DvTpiniW9s3APmHRYn8FroUWyfnLtrsid5Mtn5EwMXHN2ed", "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3", "5Hddm3iBFD2GLT5ik7LZnT3XJUnRnN8PoeCFgGQgawUVKNm8", "5HEo565WAy4Dbq3Sv271SAi7syBSofyfhhwRNjFNSM2gP9M2", "5FcXnzNo3mrqReTEY4ftkg5iXRBi61iyvM4W1bywZLRqfxAY", "5HNQURvmjjYhTSksi8Wfsw676b4owGwfLR2BFAQzG7H3HhYf", "5FLKnbMjHY8LarHZvk2q2RY9drWFbpxjAcR5x8tjr3GqtU6F", "5Gpt8XWFTXmKrRF1qaxcBQLvnPLpKi6Pt2XC4vVQR7gqNKtU"])
         self.blockchain_sync_delta = self.get_config_value('blockchain_sync_delta', {'bitcoin': 100, 'doge': 100})
         self.is_grace_period = self.get_config_value('is_grace_period', False)
-        self.inmemory_hotkeys = self.get_config_value('inmemory_hotkeys', [])
-        self.penalty_rate = self.get_config_value('penalty_rate', 0.3)
         return self
     
     def get_blockchain_sync_delta(self, network):

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -161,32 +161,21 @@ class Validator(BaseValidatorNeuron):
             return 0
         bt.logging.info(f"Cross-Validation: {hot_key=} Test passed")
 
-        score = self.scorer.calculate_score(
-            network,
-            response_time,
-            start_block_height,
-            last_block_height,
-            self.block_height_cache[network],
-            miner_distribution,
-            multiple_ips,
-            multiple_run_ids
-        )
-
-        if self.validator_config.is_grace_period and response.version == 5:
-            covered_blocks = last_block_height - start_block_height
-            ideal_score = self.scorer.calculate_score(
+        if self.validator_config.is_grace_period and response.version == 4:
+            score = max(score, self.validator_config.grace_threshold)
+            bt.logging.info(f"Miner version: {response.version}, setting score to: {score}")
+        else:
+            score = self.scorer.calculate_score(
                 network,
                 response_time,
-                100,
-                self.block_height_cache[network],
+                start_block_height,
+                last_block_height,
                 self.block_height_cache[network],
                 miner_distribution,
                 multiple_ips,
                 multiple_run_ids
             )
-            
-            score = ideal_score * (2 / (1 + np.exp(-(covered_blocks - self.validator_config.grace_threshold_block) / self.validator_config.grace_threshold_block)))
-            # score = max(score, self.validator_config.grace_threshold)
+
         return score
 
     async def forward(self):

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -185,7 +185,7 @@ class Validator(BaseValidatorNeuron):
                 multiple_run_ids
             )
             
-            score = ideal_score * (2 / (1 + np.exp(-(covered_blocks - 1e+5)/1e+5)))
+            score = ideal_score * (2 / (1 + np.exp(-(covered_blocks - self.validator_config.grace_threshold_block) / self.validator_config.grace_threshold_block)))
             # score = max(score, self.validator_config.grace_threshold)
         return score
 

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -162,7 +162,7 @@ class Validator(BaseValidatorNeuron):
         bt.logging.info(f"Cross-Validation: {hot_key=} Test passed")
 
         if self.validator_config.is_grace_period and response.version == 4:
-            score = max(score, self.validator_config.grace_threshold)
+            score = max(score, self.validator_config.grace_threshold_score)
             bt.logging.info(f"Miner version: {response.version}, setting score to: {score}")
         else:
             score = self.scorer.calculate_score(


### PR DESCRIPTION
## Description

_During grace period let v2 miners get higher score with indexed 100K blocks than v1 miners with entire blockchain. In order to do it, check miner version, compensate them in that case using sigmoid function and config field - grace_threshold_block. It'll be stored in https://subnet-15-cfg.s3.fr-par.scw.cloud/validator3.json_

## Acceptance Criteria

- [x] _Add grace_threshold_block field in the validator config with default value of 100K._
- [x] _Let v2 miners get higher score with indexed more than grace_threshold_block blocks than v1 miners with entire blockchain._
