### PR TITLE
SN1-536 handle llm corner cases onvalidator side

### DIFF
--- a/insights/api/insight_api.py
+++ b/insights/api/insight_api.py
@@ -61,26 +61,9 @@ class APIServer:
             bt.logging.info(f"excluded_uids are {self.excluded_uids}")
             bt.logging.info(f"Responses are {responses}")
             if not responses:
-                # TODO: i have received 0 responses, this api is not banned, this api should return another message
-                return "This API is banned."
+                # TODO: I have received 0 responses due to some issues
+                return "Please try again. Can't receive any responses due to the poor network connection."
             response = random.choice(responses)
-            
-            if response.error == protocol.LLM_ERROR_TYPE_NOT_SUPPORTED:
-            # If the validator received the error "Query is not allowed.", It should error out(ChatApp would handle it accordingly)
-                return "Query is not allowed"
-        
-            if response.error == protocol.LLM_ERROR_SEARCH_TARGET_NOT_SUPPORTED:
-                # If the validator receives the error 'Cannot find the specific template', it should invoke the generic LLM endpoint passing the same user text.
-                responses, blacklist_axon_ids =  await self.text_query_api(
-                    axons=top_miner_axons,
-                    network=network,
-                    text=text,
-                    is_generic_llm=True,
-                    timeout=self.config.timeout
-                )
-            if not responses:
-                return "This hotkey is banned."
-            response = random.choice(responses)        
             return response
                 
         @self.app.get("/")

--- a/insights/api/insight_api.py
+++ b/insights/api/insight_api.py
@@ -46,7 +46,6 @@ class APIServer:
                 axons=top_miner_axons,
                 network=network,
                 text=text,
-                is_generic_llm=False,
                 timeout=self.config.timeout
                 )
             blacklist_axons = np.array(top_miner_axons)[blacklist_axon_ids]

--- a/insights/api/query.py
+++ b/insights/api/query.py
@@ -30,10 +30,9 @@ class TextQueryAPI(SubnetsAPI):
         self.netuid = 15
         self.name = "LlmQuery"
 
-    def prepare_synapse(self, network:str, text: str, is_generic_llm: bool) -> LlmQuery:
+    def prepare_synapse(self, network:str, text: str) -> LlmQuery:
         synapse = LlmQuery(
             network=network,
-            is_generic_llm=is_generic_llm,
             messages=[
                 LlmMessage(
                     type=protocol.LLM_MESSAGE_TYPE_USER,

--- a/insights/protocol.py
+++ b/insights/protocol.py
@@ -100,7 +100,7 @@ class BaseSynapse(bt.Synapse):
 
 class Discovery(BaseSynapse):
     output: DiscoveryOutput = None
-
+                        
     def deserialize(self):
         return self
 
@@ -148,7 +148,7 @@ class LlmMessage(BaseModel):
 class LlmQuery(BaseSynapse):
     network: str = None    
     # decide whether to invoke a generic llm endpoint or not
-    is_generic_llm: bool = False  
+    # is_generic_llm: bool = False  
     # messages: conversation history for llm agent to use as context
     messages: List[LlmMessage] = None
 

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -86,6 +86,12 @@ class Validator(BaseValidatorNeuron):
         super(Validator, self).__init__(config)
         self.sync_validator()
         self.uid_batch_generator = get_uids_batch(self, self.config.neuron.sample_size)
+        if config.enable_api:
+            self.api_server = APIServer(
+                config=self.config,
+                wallet=self.wallet,
+                metagraph=self.metagraph
+            )
 
     def cross_validate(self, axon, node, start_block_height, last_block_height):
         try:
@@ -248,12 +254,13 @@ if __name__ == "__main__":
 
     with Validator() as validator:
         if validator.config.enable_api:
-            api_server = APIServer(
-                config=validator.config,
-                wallet=validator.wallet,
-                metagraph=validator.metagraph
-            )
-            api_server_thread = threading.Thread(target=run_api_server, args=(api_server,))
+            if not validator.api_server:
+                validator.api_server = APIServer(
+                    config=validator.config,
+                    wallet=validator.wallet,
+                    metagraph=validator.metagraph
+                )
+            api_server_thread = threading.Thread(target=run_api_server, args=(validator.api_server,))
             api_server_thread.start()
 
         while True:

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -192,6 +192,8 @@ class Validator(BaseValidatorNeuron):
             return None
 
     async def forward(self):
+        # Update the metagraph of api_server as the one of validator is updated.
+        self.api_server.metagraph = self.metagraph
         uids = next(self.uid_batch_generator, None)
         if uids is None:
             self.uid_batch_generator = get_uids_batch(self, self.config.neuron.sample_size)

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -1,7 +1,6 @@
 # The MIT License (MIT)
 # Copyright © 2023 Yuma Rao
 # Copyright © 2023 aph5nt
-import threading
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the “Software”), to deal in the Software without restriction, including without limitation
 # the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
@@ -23,6 +22,7 @@ import torch
 import bittensor as bt
 import os
 import yaml
+import threading
 
 from insights.protocol import Discovery, DiscoveryOutput, MAX_MINER_INSTANCE
 


### PR DESCRIPTION
## Description

_The logic of chatapi on backend change. Miners don't return error code and handle different error using openai api or corcel api and always return messages. So validators don't have to handle errors but play a proxy role. Based on the change of the logic, remove some fields in API and update protocol, query, api, and validator._

## Acceptance Criteria

- [x] _remove is_generic_llm field from protocol, query and insight_api coz it is no more required._
- [x] _If the validator receives no response, this case should be of poor network connection. The current logic of api is that a validator querys top n miners and select one randomly among the responses received from top miners. So if a validator doesn't receive any response, all of the top n miners dont response._
- [x] _In the current validator code, i found that there is no update part of api metagraph. added this part in forward method when the metagraph of a validator is updated._
- [x] _Remove error-handling part of api on validator._ 

