### PR TITLE
SN1-506 Handle variation request

### DIFF
--- a/insights/api/insight_api.py
+++ b/insights/api/insight_api.py
@@ -12,7 +12,7 @@ import yaml
 from insights import protocol
 from insights.api.query import TextQueryAPI
 from insights.api.get_query_axons import get_query_api_axons
-from insights.api.schema.chat import ChatMessageRequest, ChatMessageResponse
+from insights.api.schema.chat import ChatMessageRequest, ChatMessageResponse, ChatMessageVariantRequest
 from neurons.validators.utils.uids import get_top_miner_uids
 from fastapi import FastAPI, Body
 import uvicorn
@@ -72,7 +72,7 @@ class APIServer:
             top_miner_uids = get_top_miner_uids(self.metagraph, self.config.top_rate, self.excluded_uids)
             bt.logging.info(f"Top miner UIDs are {top_miner_uids}")
             top_miner_axons = await get_query_api_axons(wallet=self.wallet, metagraph=self.metagraph, uids=top_miner_uids)
-            bt.logging.info(f"top miner axons: {top_miner_axons}")
+            bt.logging.info(f"Top miner axons: {top_miner_axons}")
             
             # get miner response
             responses, blacklist_axon_ids =  await self.text_query_api(
@@ -80,7 +80,12 @@ class APIServer:
                 network=query.network,
                 text=query.prompt,
                 timeout=self.config.timeout
-                )
+            )
+            
+            if not responses:
+                # TODO: I have received 0 responses due to some issues
+                return "Please try again. Can't receive any responses due to the poor network connection."
+            
             blacklist_axons = np.array(top_miner_axons)[blacklist_axon_ids]
             blacklist_uids = np.where(np.isin(np.array(self.metagraph.axons), blacklist_axons))[0]
             # get responded miner uids among top miners
@@ -91,15 +96,38 @@ class APIServer:
             # If the number of excluded_uids is bigger than top x percentage of the whole axons, format it.
             if len(self.excluded_uids) > int(self.metagraph.n * self.config.top_rate):
                 bt.logging.info(f"Excluded UID list is too long")
-                self.excluded_uids = []
-            bt.logging.info(f"excluded_uids are {self.excluded_uids}")
+                self.excluded_uids = []            
+            bt.logging.info(f"Excluded_uids are {self.excluded_uids}")
+
             bt.logging.info(f"Responses are {responses}")
+            
+            selected = random.choice(len(responses))
+
+            # return response and the hotkey of randomly selected miner
+            return ChatMessageResponse(text=responses[selected], miner_id=self.metagraph.hotkeys[responded_uids[selected]])
+        
+        @self.app.post("api/text_query/variant")
+        async def get_response_variant(query: ChatMessageVariantRequest = Body(...)):
+            bt.logging.info(f"Miner {query.miner_id} received a variant request.")
+            
+            miner_axon = await get_query_api_axons(wallet=self.wallet, metagraph=self.metagraph, uids=query.miner_id)
+            bt.logging.info(f"Miner axon: {miner_axon}")
+            
+            responses, blacklist_axon_ids =  await self.text_query_api(
+                axons=miner_axon,
+                network=query.network,
+                text=query.prompt,
+                timeout=self.config.timeout
+            )
+            
             if not responses:
                 # TODO: I have received 0 responses due to some issues
                 return "Please try again. Can't receive any responses due to the poor network connection."
-            selected = random.choice(len(responses))
+            
+            bt.logging.info(f"Variant: {responses}")
+
             # return response and the hotkey of randomly selected miner
-            return ChatMessageResponse(text=responses[selected], miner_id=self.metagraph.hotkeys[responded_uids[selected]])
+            return ChatMessageResponse(text=responses[0], miner_id=query.miner_id)
                 
         @self.app.get("/")
         def healthcheck():

--- a/insights/api/schema/chat.py
+++ b/insights/api/schema/chat.py
@@ -5,6 +5,13 @@ class ChatMessageRequest(BaseModel):
     user_id: int
     prompt: str
     
+class ChatMessageVariantRequest(BaseModel):
+    network: str
+    user_id: int
+    prompt: str
+    temperature: float
+    miner_id: str
+    
 class ChatMessageResponse(BaseModel):
     text: str
     miner_id: str


### PR DESCRIPTION
A validator would be able to receive a user request to generate a variation on a previously generated message. I will return the new message and store the fact that a specific miner's message had a variation request.

- [x] _Return generate variation text and miner ID._
- [x] _Receive temperature._

On the miner side, receiving temperature parameter should be implemented to generate variation.