### PR TITLE
SN1-564 Add scoring for miners executing real user prompts

### DIFF
--- a/insights/api/insight_api.py
+++ b/insights/api/insight_api.py
@@ -72,6 +72,7 @@ class APIServer:
             config: None,
             wallet: None,
             metagraph: None,
+            scores: None,
         ):
         self.app = FastAPI()
         self.config = config
@@ -79,6 +80,9 @@ class APIServer:
         self.text_query_api = TextQueryAPI(wallet=self.wallet)
         self.metagraph = metagraph
         self.excluded_uids = []
+        self.scores = scores
+        
+        bt.logging.info(f"Initialized all scores to 0")
         
         @self.app.get("/api/text_query")
         async def get_response(network:str, text: str):            

--- a/insights/api/insight_api.py
+++ b/insights/api/insight_api.py
@@ -154,6 +154,7 @@ class APIServer:
         self.config = config
         self.wallet = wallet
         self.text_query_api = TextQueryAPI(wallet=self.wallet)
+        self.subtensor = subtensor
         self.metagraph = metagraph
         self.excluded_uids = []
         self.scores = scores

--- a/insights/api/insight_api.py
+++ b/insights/api/insight_api.py
@@ -159,8 +159,6 @@ class APIServer:
         self.excluded_uids = []
         self.scores = scores
         
-        bt.logging.info(f"Initialized all scores to 0")
-        
         @self.app.get("/api/text_query")
         async def get_response(network:str, text: str):            
             # select top miner            

--- a/insights/api/insight_api.py
+++ b/insights/api/insight_api.py
@@ -8,6 +8,8 @@ from datetime import datetime
 import traceback
 import torch
 import bittensor as bt
+from rich.table import Table
+from rich.console import Console
 import yaml
 
 from insights import protocol
@@ -23,6 +25,79 @@ import uvicorn
 bt.debug()
 
 class APIServer:
+    def set_weights(self):
+        """
+        Sets the validator weights to the metagraph hotkeys based on the scores it has received from the miners. The weights determine the trust and incentive level the validator assigns to miner nodes on the network.
+        """
+        try:
+            # Check if self.scores contains any NaN values and log a warning if it does.
+            if torch.isnan(self.scores).any():
+                bt.logging.warning(
+                    f"Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward functions."
+                )
+
+            # Calculate the average reward for each uid across non-zero values.
+            # Replace any NaN values with 0.
+            raw_weights = torch.nn.functional.normalize(self.scores, p=1, dim=0)
+
+            # Process the raw weights to final_weights via subtensor limitations.
+            (
+                processed_weight_uids,
+                processed_weights,
+            ) = bt.utils.weight_utils.process_weights_for_netuid(
+                uids=self.metagraph.uids.to("cpu"),
+                weights=raw_weights.to("cpu"),
+                netuid=self.config.netuid,
+                subtensor=self.subtensor,
+                metagraph=self.metagraph,
+            )
+
+            # Convert to uint16 weights and uids.
+            (
+                uint_uids,
+                uint_weights,
+            ) = bt.utils.weight_utils.convert_weights_and_uids_for_emit(
+                uids=processed_weight_uids, weights=processed_weights
+            )
+            table = Table(title="All Weights")
+            table.add_column("uid", justify="right", style="cyan", no_wrap=True)
+            table.add_column("weight", style="magenta")
+            table.add_column("score", style="magenta")
+            uids_and_weights = list(
+                zip(uint_uids, uint_weights)
+                )
+            # Sort by weights descending.
+            sorted_uids_and_weights = sorted(
+                uids_and_weights, key=lambda x: x[1], reverse=True
+            )
+            for uid, weight in sorted_uids_and_weights:
+                table.add_row(
+                    str(uid),
+                    str(round(weight, 4)),
+                    str(int(self.scores[uid].item())),
+                )
+            console = Console()
+            console.print(table)
+
+            # Set the weights on chain via our subtensor connection.
+            self.subtensor.set_weights(
+                wallet=self.wallet,
+                netuid=self.config.netuid,
+                uids=processed_weight_uids,
+                weights=processed_weights,
+                wait_for_finalization=False,
+                wait_for_inclusion=False,
+                version_key=self.spec_version
+            )
+
+            with self.lock:
+                self.last_weights_set_block = self.block
+
+            bt.logging.success("Finished setting weights.")
+        except Exception as e:
+            bt.logging.error(
+                f"Failed to set weights on chain with exception: { e }"
+            )
     def is_response_status_code_valid(self, response):
             status_code = response.axon.status_code
             status_message = response.axon.status_message

--- a/insights/api/insight_api.py
+++ b/insights/api/insight_api.py
@@ -146,6 +146,7 @@ class APIServer:
             self,
             config: None,
             wallet: None,
+            subtensor: None,
             metagraph: None,
             scores: None,
         ):

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -201,7 +201,7 @@ class Validator(BaseValidatorNeuron):
             return None
 
     async def forward(self):
-        # Update the metagraph of api_server as the one of validator is updated.
+        # Update the subtensor, metagraph, scores of api_server as the one of validator is updated.
         self.api_server.subtensor = self.subtensor
         self.api_server.metagraph = self.metagraph
         self.api_server.scores = self.scores

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -91,7 +91,8 @@ class Validator(BaseValidatorNeuron):
             self.api_server = APIServer(
                 config=self.config,
                 wallet=self.wallet,
-                metagraph=self.metagraph
+                metagraph=self.metagraph,
+                scores=self.scores
             )
 
     def cross_validate(self, axon, node, start_block_height, last_block_height):
@@ -201,6 +202,7 @@ class Validator(BaseValidatorNeuron):
     async def forward(self):
         # Update the metagraph of api_server as the one of validator is updated.
         self.api_server.metagraph = self.metagraph
+        self.api_server.scores = self.scores
         uids = next(self.uid_batch_generator, None)
         if uids is None:
             self.uid_batch_generator = get_uids_batch(self, self.config.neuron.sample_size)

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -54,7 +54,7 @@ class Validator(BaseValidatorNeuron):
         parser.add_argument("--api_port", type=int, default=8001, help="API endpoint port.")
         parser.add_argument("--timeout", type=int, default=40, help="Timeout.")
         parser.add_argument("--top_rate", type=float, default=1, help="Best selection percentage")
-        parser.add_argument("--user_query_moving_average_alpha", type=float, default=0.001, help="Moving average alpha for scoring user query miners.")
+        parser.add_argument("--user_query_moving_average_alpha", type=float, default=0.0001, help="Moving average alpha for scoring user query miners.")
 
         bt.subtensor.add_args(parser)
         bt.logging.add_args(parser)

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -261,7 +261,8 @@ if __name__ == "__main__":
                 validator.api_server = APIServer(
                     config=validator.config,
                     wallet=validator.wallet,
-                    metagraph=validator.metagraph
+                    metagraph=validator.metagraph,
+                    scores=validator.scores
                 )
             api_server_thread = threading.Thread(target=run_api_server, args=(validator.api_server,))
             api_server_thread.start()

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -54,6 +54,7 @@ class Validator(BaseValidatorNeuron):
         parser.add_argument("--api_port", type=int, default=8001, help="API endpoint port.")
         parser.add_argument("--timeout", type=int, default=40, help="Timeout.")
         parser.add_argument("--top_rate", type=float, default=1, help="Best selection percentage")
+        parser.add_argument("--user_query_moving_average_alpha", type=float, default=0.001, help="Moving average alpha for scoring user query miners.")
 
         bt.subtensor.add_args(parser)
         bt.logging.add_args(parser)
@@ -225,7 +226,7 @@ class Validator(BaseValidatorNeuron):
 
             rewards = torch.FloatTensor(rewards)
             self.update_scores(rewards, uids)
-        else: 
+        else:  
             bt.logging.info('Skipping update_scores() as no responses were valid')
 
     def sync_validator(self):

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -91,6 +91,7 @@ class Validator(BaseValidatorNeuron):
             self.api_server = APIServer(
                 config=self.config,
                 wallet=self.wallet,
+                subtensor=self.subtensor,
                 metagraph=self.metagraph,
                 scores=self.scores
             )
@@ -201,6 +202,7 @@ class Validator(BaseValidatorNeuron):
 
     async def forward(self):
         # Update the metagraph of api_server as the one of validator is updated.
+        self.api_server.subtensor = self.subtensor
         self.api_server.metagraph = self.metagraph
         self.api_server.scores = self.scores
         uids = next(self.uid_batch_generator, None)
@@ -261,6 +263,7 @@ if __name__ == "__main__":
                 validator.api_server = APIServer(
                     config=validator.config,
                     wallet=validator.wallet,
+                    subtensor=validator.subtensor,
                     metagraph=validator.metagraph,
                     scores=validator.scores
                 )


### PR DESCRIPTION
## Description
_User replying to real user prompts should be scored more. Implemented this function on the API side.

## Acceptance criteria
- [x] _Implemented functions for rewarding and setting weights to miners respond to the user queries in API._
- [x] _Sync with the current validator regarding the scores and subtensor._
- [x] _Let moving average alpha small as this scoring part affects the score of miners much less than the regular challenges. Its default value is 0.0001 and its configurable now._
- [x] _There is no rewarding mechanism for generic user query so set the score for miners respond to the user queries as a constant-0.5. We can update the get_reward function further._
